### PR TITLE
Fixed error "AddComponent with MonoBehaviour is not allowed. Create a…

### DIFF
--- a/source/Assets/Scripts/InfinarioSDK/FakeObject.cs
+++ b/source/Assets/Scripts/InfinarioSDK/FakeObject.cs
@@ -1,0 +1,6 @@
+﻿using UnityEngine;
+
+namespace Infinario.Sender {
+    public class FakeObject : MonoBehaviour{
+    }
+}

--- a/source/Assets/Scripts/InfinarioSDK/Sender.cs
+++ b/source/Assets/Scripts/InfinarioSDK/Sender.cs
@@ -22,7 +22,7 @@ namespace Infinario.Sender
 			{
 				var go = new GameObject("Infinario Coroutines");
 				UnityEngine.Object.DontDestroyOnLoad(go);
-				_coroutineObject = go.AddComponent<MonoBehaviour>();
+				_coroutineObject = go.AddComponent<FakeObject>();
 			}		
 			_coroutineObject.StartCoroutine (coroutine);
 		}


### PR DESCRIPTION
Got error in Unity 5.4.1:

> AddComponent with MonoBehaviour is not allowed. Create a class that derives from MonoBehaviour and add it instead.

So, just add empty script to fix it.